### PR TITLE
"List my articles" endpoints, serializations to different Article types

### DIFF
--- a/devto/articles.go
+++ b/devto/articles.go
@@ -26,23 +26,40 @@ func (ar *ArticlesResource) List(ctx context.Context, opt ArticleListOptions) ([
 	if err != nil {
 		return nil, err
 	}
-	req, _ := ar.API.NewRequest(http.MethodGet, fmt.Sprintf("api/articles?%s", q.Encode()), nil)
-	res, _ := ar.API.HTTPClient.Do(req)
+	req, err := ar.API.NewRequest(http.MethodGet, fmt.Sprintf("api/articles?%s", q.Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := ar.API.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
 	cont := decodeResponse(res)
-	json.Unmarshal(cont, &l)
+	if err := json.Unmarshal(cont, &l); err != nil {
+		return nil, err
+	}
 	return l, nil
 }
 
 // Find will retrieve an Article matching the ID passed.
 func (ar *ArticlesResource) Find(ctx context.Context, id uint32) (Article, error) {
 	var art Article
-	req, _ := ar.API.NewRequest(http.MethodGet, fmt.Sprintf("api/articles/%d", id), nil)
+	req, err := ar.API.NewRequest(http.MethodGet, fmt.Sprintf("api/articles/%d", id), nil)
+	if err != nil {
+		return art, err
+	}
+
 	res, err := ar.API.HTTPClient.Do(req)
 	if err != nil {
 		return art, err
 	}
 	cont := decodeResponse(res)
-	json.Unmarshal(cont, &art)
+	if err := json.Unmarshal(cont, &art); err != nil {
+		return Article{}, err
+	}
 	return art, nil
 }
 
@@ -65,7 +82,9 @@ func (ar *ArticlesResource) New(ctx context.Context, a Article) (Article, error)
 		return a, err
 	}
 	content := decodeResponse(res)
-	json.Unmarshal(content, &a)
+	if err := json.Unmarshal(content, &a); err != nil {
+		return Article{}, err
+	}
 	return a, nil
 }
 
@@ -90,6 +109,8 @@ func (ar *ArticlesResource) Update(ctx context.Context, a Article) (Article, err
 		return a, err
 	}
 	content := decodeResponse(res)
-	json.Unmarshal(content, &a)
+	if err := json.Unmarshal(content, &a); err != nil {
+		return Article{}, err
+	}
 	return a, nil
 }

--- a/devto/articles.go
+++ b/devto/articles.go
@@ -51,9 +51,84 @@ func (ar *ArticlesResource) ListForTag(ctx context.Context, tag string, page int
 }
 
 // ListForUser is a convenience method for retrieving articles
-// by a particular user, calling the base List method.
+// written by a particular user, calling the base List method.
 func (ar *ArticlesResource) ListForUser(ctx context.Context, username string, page int) ([]Article, error) {
 	return ar.List(ctx, ArticleListOptions{Username: username, Page: page})
+}
+
+// ListMyPublishedArticles lists all published articles
+// written by the user authenticated with this client,
+// erroring if the caller is not authenticated. Articles in
+// the response will be listed in reverse chronological order
+// by their publication times.
+//
+// If opts is nil, then no query parameters will be sent; the
+// page number will be 1 and the page size will be 30
+// articles.
+func (ar *ArticlesResource) ListMyPublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+	return ar.listMyArticles(ctx, "api/articles/me/published", opts)
+}
+
+// ListMyUnpublishedArticles lists all unpublished articles
+// written by the user authenticated with this client,
+// erroring if the caller is not authenticated. Articles in
+// the response will be listed in reverse chronological order
+// by their creation times.
+//
+// If opts is nil, then no query parameters will be sent; the
+// page number will be 1 and the page size will be 30
+// articles.
+func (ar *ArticlesResource) ListMyUnpublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+	return ar.listMyArticles(ctx, "api/articles/me/unpublished", opts)
+}
+
+// ListAllMyArticles lists all articles written by the user
+// authenticated with this client, erroring if the caller is
+// not authenticated. Articles in the response will be listed
+// in reverse chronological order by their creation times,
+// with unpublished articles listed before published articles.
+//
+// If opts is nil, then no query parameters will be sent; the
+// page number will be 1 and the page size will be 30
+// articles.
+func (ar *ArticlesResource) ListAllMyArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+	return ar.listMyArticles(ctx, "api/articles/me/all", opts)
+}
+
+func (ar *ArticlesResource) listMyArticles(
+	ctx context.Context,
+	endpoint string,
+	opts *MyArticlesOptions,
+) ([]Article, error) {
+	if ar.API.Config.InsecureOnly {
+		return nil, ErrProtectedEndpoint
+	}
+
+	req, err := ar.API.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(APIKeyHeader, ar.API.Config.APIKey)
+
+	if opts != nil {
+		q, err := query.Values(opts)
+		if err != nil {
+			return nil, err
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	res, err := ar.API.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var articles []Article
+	if err := json.NewDecoder(res.Body).Decode(&articles); err != nil {
+		return nil, err
+	}
+	return articles, nil
 }
 
 // Find will retrieve an Article matching the ID passed.

--- a/devto/articles.go
+++ b/devto/articles.go
@@ -20,8 +20,8 @@ type ArticlesResource struct {
 // can be narrowed down, filtered or enhanced using query
 // parameters as specified on the documentation.
 // See: https://docs.dev.to/api/#tag/articles/paths/~1articles/get
-func (ar *ArticlesResource) List(ctx context.Context, opt ArticleListOptions) ([]Article, error) {
-	var l []Article
+func (ar *ArticlesResource) List(ctx context.Context, opt ArticleListOptions) ([]ListedArticle, error) {
+	var l []ListedArticle
 	q, err := query.Values(opt)
 	if err != nil {
 		return nil, err
@@ -46,13 +46,13 @@ func (ar *ArticlesResource) List(ctx context.Context, opt ArticleListOptions) ([
 
 // ListForTag is a convenience method for retrieving articles
 // for a particular tag, calling the base List method.
-func (ar *ArticlesResource) ListForTag(ctx context.Context, tag string, page int) ([]Article, error) {
+func (ar *ArticlesResource) ListForTag(ctx context.Context, tag string, page int) ([]ListedArticle, error) {
 	return ar.List(ctx, ArticleListOptions{Tags: tag, Page: page})
 }
 
 // ListForUser is a convenience method for retrieving articles
 // written by a particular user, calling the base List method.
-func (ar *ArticlesResource) ListForUser(ctx context.Context, username string, page int) ([]Article, error) {
+func (ar *ArticlesResource) ListForUser(ctx context.Context, username string, page int) ([]ListedArticle, error) {
 	return ar.List(ctx, ArticleListOptions{Username: username, Page: page})
 }
 
@@ -65,7 +65,7 @@ func (ar *ArticlesResource) ListForUser(ctx context.Context, username string, pa
 // If opts is nil, then no query parameters will be sent; the
 // page number will be 1 and the page size will be 30
 // articles.
-func (ar *ArticlesResource) ListMyPublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+func (ar *ArticlesResource) ListMyPublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]ListedArticle, error) {
 	return ar.listMyArticles(ctx, "api/articles/me/published", opts)
 }
 
@@ -78,7 +78,7 @@ func (ar *ArticlesResource) ListMyPublishedArticles(ctx context.Context, opts *M
 // If opts is nil, then no query parameters will be sent; the
 // page number will be 1 and the page size will be 30
 // articles.
-func (ar *ArticlesResource) ListMyUnpublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+func (ar *ArticlesResource) ListMyUnpublishedArticles(ctx context.Context, opts *MyArticlesOptions) ([]ListedArticle, error) {
 	return ar.listMyArticles(ctx, "api/articles/me/unpublished", opts)
 }
 
@@ -91,15 +91,18 @@ func (ar *ArticlesResource) ListMyUnpublishedArticles(ctx context.Context, opts 
 // If opts is nil, then no query parameters will be sent; the
 // page number will be 1 and the page size will be 30
 // articles.
-func (ar *ArticlesResource) ListAllMyArticles(ctx context.Context, opts *MyArticlesOptions) ([]Article, error) {
+func (ar *ArticlesResource) ListAllMyArticles(ctx context.Context, opts *MyArticlesOptions) ([]ListedArticle, error) {
 	return ar.listMyArticles(ctx, "api/articles/me/all", opts)
 }
 
+// listMyArticles serves for handling roundtrips to the
+// /api/articles/me/* endpoints, requesting articles from the
+// endpoint passed in, and returning a list of articles.
 func (ar *ArticlesResource) listMyArticles(
 	ctx context.Context,
 	endpoint string,
 	opts *MyArticlesOptions,
-) ([]Article, error) {
+) ([]ListedArticle, error) {
 	if ar.API.Config.InsecureOnly {
 		return nil, ErrProtectedEndpoint
 	}
@@ -124,7 +127,7 @@ func (ar *ArticlesResource) listMyArticles(
 	}
 	defer res.Body.Close()
 
-	var articles []Article
+	var articles []ListedArticle
 	if err := json.NewDecoder(res.Body).Decode(&articles); err != nil {
 		return nil, err
 	}
@@ -151,23 +154,25 @@ func (ar *ArticlesResource) Find(ctx context.Context, id uint32) (Article, error
 }
 
 // New will create a new article on dev.to
-func (ar *ArticlesResource) New(ctx context.Context, a Article) (Article, error) {
+func (ar *ArticlesResource) New(ctx context.Context, u ArticleUpdate) (Article, error) {
 	if ar.API.Config.InsecureOnly {
-		return a, ErrProtectedEndpoint
+		return Article{}, ErrProtectedEndpoint
 	}
-	cont, err := json.Marshal(a)
+	cont, err := json.Marshal(&u)
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
 	req, err := ar.API.NewRequest(http.MethodPost, "api/articles", strings.NewReader(string(cont)))
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
 	req.Header.Add(APIKeyHeader, ar.API.Config.APIKey)
 	res, err := ar.API.HTTPClient.Do(req)
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
+
+	var a Article
 	content := decodeResponse(res)
 	if err := json.Unmarshal(content, &a); err != nil {
 		return Article{}, err
@@ -178,23 +183,25 @@ func (ar *ArticlesResource) New(ctx context.Context, a Article) (Article, error)
 // Update will mutate the resource by id, and all the changes
 // performed to the Article will be applied, thus validation
 // on the API side.
-func (ar *ArticlesResource) Update(ctx context.Context, a Article) (Article, error) {
+func (ar *ArticlesResource) Update(ctx context.Context, u ArticleUpdate, id uint32) (Article, error) {
 	if ar.API.Config.InsecureOnly {
-		return a, ErrProtectedEndpoint
+		return Article{}, ErrProtectedEndpoint
 	}
-	cont, err := json.Marshal(a)
+	cont, err := json.Marshal(&u)
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
-	req, err := ar.API.NewRequest(http.MethodPut, fmt.Sprintf("api/articles/%d", a.ID), strings.NewReader(string(cont)))
+	req, err := ar.API.NewRequest(http.MethodPut, fmt.Sprintf("api/articles/%d", id), strings.NewReader(string(cont)))
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
 	req.Header.Add(APIKeyHeader, ar.API.Config.APIKey)
 	res, err := ar.API.HTTPClient.Do(req)
 	if err != nil {
-		return a, err
+		return Article{}, err
 	}
+
+	var a Article
 	content := decodeResponse(res)
 	if err := json.Unmarshal(content, &a); err != nil {
 		return Article{}, err

--- a/devto/articles.go
+++ b/devto/articles.go
@@ -44,6 +44,18 @@ func (ar *ArticlesResource) List(ctx context.Context, opt ArticleListOptions) ([
 	return l, nil
 }
 
+// ListForTag is a convenience method for retrieving articles
+// for a particular tag, calling the base List method.
+func (ar *ArticlesResource) ListForTag(ctx context.Context, tag string, page int) ([]Article, error) {
+	return ar.List(ctx, ArticleListOptions{Tags: tag, Page: page})
+}
+
+// ListForUser is a convenience method for retrieving articles
+// by a particular user, calling the base List method.
+func (ar *ArticlesResource) ListForUser(ctx context.Context, username string, page int) ([]Article, error) {
+	return ar.List(ctx, ArticleListOptions{Username: username, Page: page})
+}
+
 // Find will retrieve an Article matching the ID passed.
 func (ar *ArticlesResource) Find(ctx context.Context, id uint32) (Article, error) {
 	var art Article

--- a/devto/articles_test.go
+++ b/devto/articles_test.go
@@ -2,6 +2,7 @@ package devto
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -46,11 +47,17 @@ func TestArticlesResource_List(t *testing.T) {
 func TestArticlesResource_ListWithQueryParams(t *testing.T) {
 	setup()
 	defer teardown()
-	testMux.HandleFunc("/api/articles?page=1&state=fresh&tag=go&top=1&username=victoravelar", func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix("username=victoravelar", r.URL.String()) {
+	testMux.HandleFunc("/api/articles", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.String(), "username=victoravelar") {
 			t.Error("url mismatch")
 		}
-		w.WriteHeader(http.StatusOK)
+
+		var articles []ListedArticle
+		if err := json.NewEncoder(w).Encode(&articles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	})
 
 	q := ArticleListOptions{

--- a/devto/articles_test.go
+++ b/devto/articles_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/VictorAvelar/devto-api-go/testdata"
 )
@@ -76,6 +77,192 @@ func TestArticlesResource_ListWithQueryParams(t *testing.T) {
 	}
 }
 
+func TestArticlesResource_ListForTag(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/api/articles", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("tag") != "go" {
+			t.Errorf(`expected "tag" query param to be "go", got "%s"`, q.Get("tag"))
+		}
+		if q.Get("page") != "3" {
+			t.Errorf(`expected "page" query param to be "3", got "%s"`, q.Get("page"))
+		}
+
+		var articles []ListedArticle
+		if err := json.NewEncoder(w).Encode(&articles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+
+	list, err := testClientPub.Articles.ListForTag(ctx, "go", 3)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 0 {
+		t.Error("response is unexpected")
+	}
+}
+
+func TestArticlesResource_ListForUser(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/api/articles", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("username") != "victoravelar" {
+			t.Errorf(`expected "username" query param to be "victoravelar", got "%s"`, q.Get("username"))
+		}
+		if q.Get("page") != "3" {
+			t.Errorf(`expected "page" query param to be "3", got "%s"`, q.Get("page"))
+		}
+
+		var articles []ListedArticle
+		if err := json.NewEncoder(w).Encode(&articles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+
+	list, err := testClientPub.Articles.ListForUser(ctx, "victoravelar", 3)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 0 {
+		t.Error("response is unexpected")
+	}
+}
+
+var gopherDay = time.Date(2009, time.November, 10, 0, 0, 0, 0, time.UTC)
+
+var myArticles = []ListedArticle{{
+	TypeOf:      "article",
+	ID:          1123,
+	Title:       "Joy of tunneling",
+	Description: "How to dig the perfect gopher hole",
+	User: User{
+		Name:     "B. Neathyourlawn",
+		Username: "bneathyourlawn",
+	},
+	TagList:   []string{"go"},
+	Published: false,
+}, {
+	TypeOf:      "article",
+	ID:          5813,
+	Title:       "Carrot stew recipe",
+	Description: "A traditional meal since gophers first came to a garden near you",
+	User: User{
+		Name:     "B. Neathyourlawn",
+		Username: "bneathyourlawn",
+	},
+	TagList:     []string{"go", "cooking"},
+	Published:   true,
+	PublishedAt: &gopherDay,
+}}
+
+func TestArticlesResource_ListMyPublishedArticles(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/api/articles/me/published", func(w http.ResponseWriter, r *http.Request) {
+		articles := myArticles[:1]
+		if err := json.NewEncoder(w).Encode(&articles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+
+	list, err := testClientPro.Articles.ListMyPublishedArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("should have gotten 1 article back, got %d", len(list))
+	}
+	if list[0].Title != "Joy of tunneling" {
+		t.Errorf(`expected title to be "Joy of tunneling", got back "%s"`, list[0].Title)
+	}
+
+	// Test without authentication
+	list, err = testClientPub.Articles.ListMyPublishedArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != ErrProtectedEndpoint {
+		t.Errorf("error should be ErrProtectedEndpoint, was %v", err)
+	}
+	if list != nil {
+		t.Errorf("should get back nil slice of articles from unauthenticated request")
+	}
+}
+
+func TestArticlesResource_ListMyUnpublishedArticles(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/api/articles/me/unpublished", func(w http.ResponseWriter, r *http.Request) {
+		articles := myArticles[1:]
+		if err := json.NewEncoder(w).Encode(&articles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+
+	list, err := testClientPro.Articles.ListMyUnpublishedArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("should have gotten 1 article back, got %d", len(list))
+	}
+	if list[0].Title != "Carrot stew recipe" {
+		t.Errorf(`expected title to be "Carrot stew recipe", got back "%s"`, list[0].Title)
+	}
+
+	// Test without authentication
+	list, err = testClientPub.Articles.ListMyUnpublishedArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != ErrProtectedEndpoint {
+		t.Errorf("error should be ErrProtectedEndpoint, was %v", err)
+	}
+	if list != nil {
+		t.Errorf("should get back nil slice of articles from unauthenticated request")
+	}
+}
+
+func TestArticlesResource_ListAllMyArticles(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/api/articles/me/all", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(&myArticles); err != nil {
+			t.Errorf("error marshalling ListedArticles to JSON: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	})
+
+	list, err := testClientPro.Articles.ListAllMyArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("should have gotten 1 article back, got %d", len(list))
+	}
+	if list[0].Title != "Joy of tunneling" {
+		t.Errorf(`expected title to be "Joy of tunneling", got back "%s"`, list[0].Title)
+	}
+	if list[1].Title != "Carrot stew recipe" {
+		t.Errorf(`expected title to be "Carrot stew recipe", got back "%s"`, list[1].Title)
+	}
+
+	// Test without authentication
+	list, err = testClientPub.Articles.ListAllMyArticles(ctx, &MyArticlesOptions{Page: 1})
+	if err != ErrProtectedEndpoint {
+		t.Errorf("error should be ErrProtectedEndpoint, was %v", err)
+	}
+	if list != nil {
+		t.Errorf("should get back nil slice of articles from unauthenticated request")
+	}
+}
+
 func TestArticlesResource_Find(t *testing.T) {
 	setup()
 	defer teardown()
@@ -104,12 +291,31 @@ func TestArticlesResource_New(t *testing.T) {
 	defer teardown()
 	testMux.HandleFunc("/api/articles", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Error("invalid method for request")
+			t.Fatal("invalid method for request")
 		}
-		cont, _ := ioutil.ReadAll(r.Body)
+
+		var au ArticleUpdate
+		if err := json.NewDecoder(r.Body).Decode(&au); err != nil {
+			t.Fatalf("error unmarshallling ArticleUpdate from JSON: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		a := Article{
+			ID:        112358,
+			Title:     au.Title,
+			Published: au.Published,
+		}
+		b, err := json.Marshal(&a)
+		if err != nil {
+			t.Errorf("error marshalling Article to JSON")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Add("content-type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		w.Write(cont)
+		w.Write(b)
 	})
 
 	res, err := testClientPro.Articles.New(ctx, ArticleUpdate{
@@ -146,10 +352,29 @@ func TestArticlesResource_Update(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Error("invalid method for request")
 		}
-		cont, _ := ioutil.ReadAll(r.Body)
+
+		var au ArticleUpdate
+		if err := json.NewDecoder(r.Body).Decode(&au); err != nil {
+			t.Fatalf("error unmarshallling ArticleUpdate from JSON: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		a := Article{
+			ID:        164198,
+			Title:     au.Title,
+			Published: au.Published,
+		}
+		b, err := json.Marshal(&a)
+		if err != nil {
+			t.Errorf("error marshalling Article to JSON")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Add("content-type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		w.Write(cont)
+		w.Write(b)
 	})
 
 	res, err := testClientPro.Articles.Update(ctx, ArticleUpdate{

--- a/devto/articles_test.go
+++ b/devto/articles_test.go
@@ -105,11 +105,13 @@ func TestArticlesResource_New(t *testing.T) {
 		w.Write(cont)
 	})
 
-	res, _ := testClientPro.Articles.New(ctx, Article{
-		TypeOf:    "article",
+	res, err := testClientPro.Articles.New(ctx, ArticleUpdate{
 		Title:     "Demo article",
 		Published: false,
 	})
+	if err != nil {
+		t.Fatalf("unexpected error publishing article: %v", err)
+	}
 
 	if res.Title != "Demo article" {
 		t.Error("article parsing failed")
@@ -120,8 +122,7 @@ func TestArticlesResource_NewFailsWhenInsecure(t *testing.T) {
 	setup()
 	defer teardown()
 
-	_, err := testClientPub.Articles.New(ctx, Article{
-		TypeOf:    "article",
+	_, err := testClientPub.Articles.New(ctx, ArticleUpdate{
 		Title:     "Demo article",
 		Published: false,
 	})
@@ -144,12 +145,13 @@ func TestArticlesResource_Update(t *testing.T) {
 		w.Write(cont)
 	})
 
-	res, _ := testClientPro.Articles.Update(ctx, Article{
-		TypeOf:    "article",
-		ID:        164198,
+	res, err := testClientPro.Articles.Update(ctx, ArticleUpdate{
 		Title:     "Demo article",
 		Published: false,
-	})
+	}, 164198)
+	if err != nil {
+		t.Fatalf("unexpected error publishing article: %v", err)
+	}
 
 	if res.Title != "Demo article" {
 		t.Error("article parsing failed")
@@ -160,12 +162,10 @@ func TestArticlesResource_UpdateFailsWhenInsecure(t *testing.T) {
 	setup()
 	defer teardown()
 
-	_, err := testClientPub.Articles.Update(ctx, Article{
-		TypeOf:    "article",
-		ID:        164198,
+	_, err := testClientPub.Articles.Update(ctx, ArticleUpdate{
 		Title:     "Demo article",
 		Published: false,
-	})
+	}, 164198)
 
 	if !reflect.DeepEqual(err, ErrProtectedEndpoint) {
 		t.Error("auth check failed")

--- a/devto/devto.go
+++ b/devto/devto.go
@@ -54,7 +54,10 @@ func NewClient(ctx context.Context, conf *Config, bc httpClient, bu string) (dev
 		bu = BaseURL
 	}
 
-	u, _ := url.Parse(bu)
+	u, err := url.Parse(bu)
+	if err != nil {
+		return nil, err
+	}
 
 	c := &Client{
 		Context:    ctx,

--- a/devto/types.go
+++ b/devto/types.go
@@ -69,7 +69,14 @@ type ArticleListOptions struct {
 	Page     int    `url:"page,omitempty"`
 }
 
-// WebURL is a class embed to override default umarshal
+// MyArticlesOptions defines pagination options used as query
+// params in the dev.to "list my articles" endpoints.
+type MyArticlesOptions struct {
+	Page    int `url:"page,omitempty"`
+	PerPage int `url:"per_page,omitempty"`
+}
+
+// WebURL is a class embed to override default unmarshal
 // behavior.
 type WebURL struct {
 	*url.URL

--- a/devto/types.go
+++ b/devto/types.go
@@ -1,6 +1,7 @@
 package devto
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 	"time"
@@ -27,36 +28,156 @@ type Organization struct {
 	ProfileImage90 *WebURL `json:"profile_image_90,omitempty"`
 }
 
+// FlareTag represents an article's flare tag, if the article
+// has one.
+type FlareTag struct {
+	Name         string `json:"name"`
+	BGColorHex   string `json:"bg_color_hex"`
+	TextColorHex string `json:"text_color_hex"`
+}
+
 // Tags are a group of topics related to an article
 type Tags []string
+
+// This deserialization logic is so that if a listed article
+// originates from the /articles endpoint instead of
+// /articles/me/*, its Published field is returned as true,
+// since /articles exclusively returns articles that have been
+// published.
+type listedArticleJSON struct {
+	TypeOf                 string        `json:"type_of,omitempty"`
+	ID                     uint32        `json:"id,omitempty"`
+	Title                  string        `json:"title,omitempty"`
+	Description            string        `json:"description,omitempty"`
+	CoverImage             *WebURL       `json:"cover_image,omitempty"`
+	PublishedAt            *time.Time    `json:"published_at,omitempty"`
+	PublishedTimestamp     string        `json:"published_timestamp,omitempty"`
+	TagList                Tags          `json:"tag_list,omitempty"`
+	Slug                   string        `json:"slug,omitempty"`
+	Path                   string        `json:"path,omitempty"`
+	URL                    *WebURL       `json:"url,omitempty"`
+	CanonicalURL           *WebURL       `json:"canonical_url,omitempty"`
+	CommentsCount          uint          `json:"comments_count,omitempty"`
+	PositiveReactionsCount uint          `json:"positive_reactions_count,omitempty"`
+	User                   User          `json:"user,omitempty"`
+	Organization           *Organization `json:"organization,omitempty"`
+	FlareTag               *FlareTag     `json:"flare_tag,omitempty"`
+	BodyMarkdown           string        `json:"body_markdown,omitempty"`
+	Published              *bool         `json:"published,omitempty"`
+}
+
+func (j *listedArticleJSON) listedArticle() ListedArticle {
+	a := ListedArticle{
+		TypeOf:                 j.TypeOf,
+		ID:                     j.ID,
+		Title:                  j.Title,
+		Description:            j.Description,
+		CoverImage:             j.CoverImage,
+		PublishedAt:            j.PublishedAt,
+		PublishedTimestamp:     j.PublishedTimestamp,
+		TagList:                j.TagList,
+		Slug:                   j.Slug,
+		Path:                   j.Path,
+		URL:                    j.URL,
+		CanonicalURL:           j.CanonicalURL,
+		CommentsCount:          j.CommentsCount,
+		PositiveReactionsCount: j.PositiveReactionsCount,
+		User:                   j.User,
+		Organization:           j.Organization,
+		FlareTag:               j.FlareTag,
+		BodyMarkdown:           j.BodyMarkdown,
+	}
+
+	if j.Published != nil {
+		a.Published = *j.Published
+	} else {
+		// "published" currently is included in the API
+		// response for dev.to's /articles/me/* endpoints,
+		// but not in /articles, so we are setting this
+		// to true since /articles only returns articles
+		// that are published.
+		a.Published = true
+	}
+	return a
+}
+
+// ListedArticle represents an article returned from one of
+// the list articles endpoints (/articles, /articles/me/*).
+type ListedArticle struct {
+	TypeOf                 string        `json:"type_of,omitempty"`
+	ID                     uint32        `json:"id,omitempty"`
+	Title                  string        `json:"title,omitempty"`
+	Description            string        `json:"description,omitempty"`
+	CoverImage             *WebURL       `json:"cover_image,omitempty"`
+	PublishedAt            *time.Time    `json:"published_at,omitempty"`
+	PublishedTimestamp     string        `json:"published_timestamp,omitempty"`
+	TagList                Tags          `json:"tag_list,omitempty"`
+	Slug                   string        `json:"slug,omitempty"`
+	Path                   string        `json:"path,omitempty"`
+	URL                    *WebURL       `json:"url,omitempty"`
+	CanonicalURL           *WebURL       `json:"canonical_url,omitempty"`
+	CommentsCount          uint          `json:"comments_count,omitempty"`
+	PositiveReactionsCount uint          `json:"positive_reactions_count,omitempty"`
+	User                   User          `json:"user,omitempty"`
+	Organization           *Organization `json:"organization,omitempty"`
+	FlareTag               *FlareTag     `json:"flare_tag,omitempty"`
+	// Only present in "/articles/me/*" endpoints
+	BodyMarkdown string `json:"body_markdown,omitempty"`
+	Published    bool   `json:"published,omitempty"`
+}
+
+// UnmarshalJSON implements the JSON Unmarshaler interface.
+func (a *ListedArticle) UnmarshalJSON(b []byte) error {
+	var j listedArticleJSON
+	if err := json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	*a = j.listedArticle()
+	return nil
+}
 
 // Article contains all the information related to a single
 // information resource from devto.
 type Article struct {
-	TypeOf                 string       `json:"type_of,omitempty"`
-	ID                     uint32       `json:"id,omitempty"`
-	Title                  string       `json:"title,omitempty"`
-	Description            string       `json:"description,omitempty"`
-	CoverImage             *WebURL      `json:"cover_image,omitempty"`
-	SocialImage            *WebURL      `json:"social_image,omitempty"`
-	PublishedAt            *time.Time   `json:"published_at,omitempty"`
-	EditedAt               *time.Time   `json:"edited_at,omitempty"`
-	CrossPostedAt          *time.Time   `json:"crossposted_at,omitempty"`
-	LastCommentAt          *time.Time   `json:"last_comment_at,omitempty"`
-	TagList                Tags         `json:"tag_list,omitempty"`
-	Tags                   string       `json:"tags,omitempty"`
-	Slug                   string       `json:"slug,omitempty"`
-	Path                   *WebURL      `json:"path,omitempty"`
-	URL                    *WebURL      `json:"url,omitempty"`
-	CanonicalURL           *WebURL      `json:"canonical_url,omitempty"`
-	CommentsCount          uint         `json:"comments_count,omitempty"`
-	PositiveReactionsCount uint         `json:"positive_reactions_count,omitempty"`
-	PublishedTimestamp     *time.Time   `json:"published_timestamp,omitempty"`
-	User                   User         `json:"user,omitempty"`
-	Organization           Organization `json:"organization,omitempty"`
-	BodyHTML               string       `json:"body_html,omitempty"`
-	BodyMarkdown           string       `json:"body_markdown,omitempty"`
-	Published              bool         `json:"published,omitempty"`
+	TypeOf                 string     `json:"type_of,omitempty"`
+	ID                     uint32     `json:"id,omitempty"`
+	Title                  string     `json:"title,omitempty"`
+	Description            string     `json:"description,omitempty"`
+	CoverImage             *WebURL    `json:"cover_image,omitempty"`
+	SocialImage            *WebURL    `json:"social_image,omitempty"`
+	ReadablePublishDate    string     `json:"readable_publish_date"`
+	PublishedAt            *time.Time `json:"published_at,omitempty"`
+	CreatedAt              *time.Time `json:"created_at,omitempty"`
+	EditedAt               *time.Time `json:"edited_at,omitempty"`
+	CrossPostedAt          *time.Time `json:"crossposted_at,omitempty"`
+	LastCommentAt          *time.Time `json:"last_comment_at,omitempty"`
+	TagList                string     `json:"tag_list,omitempty"`
+	Tags                   Tags       `json:"tags,omitempty"`
+	Slug                   string     `json:"slug,omitempty"`
+	Path                   *WebURL    `json:"path,omitempty"`
+	URL                    *WebURL    `json:"url,omitempty"`
+	CanonicalURL           *WebURL    `json:"canonical_url,omitempty"`
+	CommentsCount          uint       `json:"comments_count,omitempty"`
+	PositiveReactionsCount uint       `json:"positive_reactions_count,omitempty"`
+	User                   User       `json:"user,omitempty"`
+	BodyHTML               string     `json:"body_html,omitempty"`
+	BodyMarkdown           string     `json:"body_markdown,omitempty"`
+}
+
+// ArticleUpdate represents an update to an article; it is
+// used as the payload in POST and PUT requests for writing
+// articles.
+type ArticleUpdate struct {
+	Title          string   `json:"title"`
+	BodyMarkdown   string   `json:"body_markdown"`
+	Published      bool     `json:"published"`
+	Series         *string  `json:"series"`
+	MainImage      string   `json:"main_image,omitempty"`
+	CanonicalURL   string   `json:"canonical_url,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	OrganizationID int32    `json:"organization_id,omitempty"`
 }
 
 // ArticleListOptions holds the query values to pass as

--- a/devto/types.go
+++ b/devto/types.go
@@ -147,6 +147,7 @@ type Article struct {
 	CoverImage             *WebURL    `json:"cover_image,omitempty"`
 	SocialImage            *WebURL    `json:"social_image,omitempty"`
 	ReadablePublishDate    string     `json:"readable_publish_date"`
+	Published              bool       `json:"published,omitempty"`
 	PublishedAt            *time.Time `json:"published_at,omitempty"`
 	CreatedAt              *time.Time `json:"created_at,omitempty"`
 	EditedAt               *time.Time `json:"edited_at,omitempty"`


### PR DESCRIPTION
This PR makes the following additions to the Go client:

* Add methods for "list my articles" endpoints (`/articles/me/*`) for listing the authenticated user's articles
* Add convenience methods to the `/articles` endpoints for listing articles by tag and user so these functionalities can be used without filling out a struct
* Define types for the variations on the `Article` type for the list endpoints, POST/PUT payloads