### PR TITLE
Handle error HTTP statuses

### DIFF
--- a/devto/devto_test.go
+++ b/devto/devto_test.go
@@ -13,7 +13,6 @@ import (
 
 // ----- Testing utilities -----
 
-// ---------- testing utilities ----------
 var (
 	testMux       *http.ServeMux
 	testClientPro *Client

--- a/devto/types.go
+++ b/devto/types.go
@@ -2,6 +2,7 @@ package devto
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -215,4 +216,15 @@ func (s *WebURL) UnmarshalJSON(b []byte) error {
 	}
 	s.URL = uri
 	return nil
+}
+
+// ErrorResponse is an error returned from a dev.to API
+// endpoint.
+type ErrorResponse struct {
+	ErrorMessage string `json:"error"`
+	Status       int    `json:"status"`
+}
+
+func (e *ErrorResponse) Error() string {
+	return fmt.Sprintf(`%d error: "%s"`, e.Status, e.ErrorMessage)
 }

--- a/devto/utilities.go
+++ b/devto/utilities.go
@@ -1,9 +1,32 @@
 package devto
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
+
+// nonSuccessfulResponse indicates that the status code for
+// the HTTP response passed in was not one of the "success"
+// (2XX) status codes
+func nonSuccessfulResponse(res *http.Response) bool { return res.StatusCode/100 != 2 }
+
+// attempt to deserialize the error response; if it succeeds,
+// the error will be an ErrorResponse, otherwise it will be
+// an error indicating that the error response could not be
+// deserialized.
+func unmarshalErrorResponse(res *http.Response) error {
+	var e ErrorResponse
+	if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+		return fmt.Errorf(
+			`unexpected error deserializing %d response: "%v"`,
+			res.StatusCode,
+			err,
+		)
+	}
+	return &e
+}
 
 func decodeResponse(r *http.Response) []byte {
 	c, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
## Description

This PR defines a type for responses given in non-2xx error statuses for dev.to endpoints so that we can 

## Motivation and context

The `net/http` client's `Do` method does not return errors for 4xx and 5xx statuses, so we need code for checking for error HTTP responses.

## How has this been tested?

This PR adds to the test coverage for each endpoint to handle 4xx error responses

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

Question on the documentation, I noticed that there is a README.md in the `docs` directory explaining each type. Would you rather have this documentation just be in the Godoc with a Godoc badge so it stays up to date with what's served in https://godoc.org/github.com/VictorAvelar/devto-api-go/devto, and then instead have docs such as usage examples in the main `README?`

If you're unsure about any of these, don't hesitate to ask. We're here to help!